### PR TITLE
Make Google Analytics ID Configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+config.js
+*.swp
+*.DS_Store

--- a/config.js
+++ b/config.js
@@ -1,0 +1,1 @@
+var GoogleAnalyticsID = "UA-57322103-1";

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <script src="js/d3.v3.min.js"></script>
 <script src="jquery.js"></script>
 <script src="js/jquery.mobile-1.4.5.min.js"></script>
-
+<script src="config.js"></script>
 
 <!--google analytics snipet-->
 <script>
@@ -15,7 +15,7 @@
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-  ga('create', 'UA-57322103-1', 'auto');
+  ga('create', GoogleAnalyticsID, 'auto');
   ga('send', 'pageview');
 </script>
 


### PR DESCRIPTION
This Pull Requests adds support for customizing the Google Analytics ID. It has now been moved to the file `config.js` along with other configuration variables. The file `config.js` is not tracked (`.gitignore`) so changing it in an installation won't interfere with future `git pull`'s unless the file is forcibly committed.